### PR TITLE
Varnish4: remove prefix:'MAIN.'

### DIFF
--- a/scripts/varnish.sh
+++ b/scripts/varnish.sh
@@ -2,5 +2,6 @@
 host=`hostname | sed "s/\./_/g"`
 
 varnishstat -1 |
+sed 's/^MAIN.//' |
 awk "{ print \"varnish.$host.\"\$1, \$2 }" |
 grep -E -v "(\..*){3}"


### PR DESCRIPTION
All stats (that we care about) are now prefixed with a 'MAIN:',
let's drop it so stat names don't change.