### PR TITLE
Add IP address to the memcached script

### DIFF
--- a/scripts/memcache-stats.sh
+++ b/scripts/memcache-stats.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 argument="$1"
 
-IP_ADDR=$(hostname -I | sed 's/ /\n/g' | grep '10\.')
+IP_ADDR=$(hostname -I | grep -oP "\b10(\.\d+){3}" )
 CLEAN_IP_ADDR=$( echo "$IP_ADDR" | tr '.' '-' )
 
 # Echo all the useful information from the `stats` memcache

--- a/scripts/memcache-stats.sh
+++ b/scripts/memcache-stats.sh
@@ -2,7 +2,7 @@
 argument="$1"
 
 IP_ADDR=$(hostname -I | sed 's/ /\n/g' | grep '10\.')
-CLEAN_IP_ADDR=$(echo "$IP_ADDR" | sed 's/\./-/g')
+CLEAN_IP_ADDR=$( echo "$IP_ADDR" | tr '.' '-' )
 
 # Echo all the useful information from the `stats` memcache
 # telnet command 

--- a/scripts/memcache-stats.sh
+++ b/scripts/memcache-stats.sh
@@ -5,8 +5,8 @@ IP_ADDR=$(hostname -I | sed 's/ /\n/g' | grep '10\.')
 CLEAN_IP_ADDR=$( echo "$IP_ADDR" | tr '.' '-' )
 
 # Echo all the useful information from the `stats` memcache
-# telnet command 
-# 
+# telnet command
+#
 # Output will resemble this:
 #
 #    memcache.pid 17576
@@ -28,7 +28,7 @@ CLEAN_IP_ADDR=$( echo "$IP_ADDR" | tr '.' '-' )
 #    memcache.slabs.5.used_chunks 11226
 #    memcache.slabs.5.free_chunks 6
 #    memcache.slabs.5.free_chunks_end 1849
-# 
+#
 (
     sleep 1
     [ "$argument" == "extended" ] && echo "stats slabs" && echo "stats items"

--- a/scripts/memcache-stats.sh
+++ b/scripts/memcache-stats.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 argument="$1"
+
+IP_ADDR=$(hostname -I | sed 's/ /\n/g' | grep '10\.')
+CLEAN_IP_ADDR=$(echo "$IP_ADDR" | sed 's/\./-/g')
+
 # Echo all the useful information from the `stats` memcache
 # telnet command 
 # 
@@ -35,4 +39,4 @@ argument="$1"
 grep STAT |
 grep -v version |
 sed -re 's/STAT (items:)?([0-9]+):/memcache.slabs.\2./' \
-     -e 's/STAT /memcache./'
+     -e "s/STAT /memcache.$CLEAN_IP_ADDR./"

--- a/scripts/memcache-stats.sh
+++ b/scripts/memcache-stats.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 argument="$1"
 
-IP_ADDR=$(hostname -I | grep -oP "\b10(\.\d+){3}" )
-CLEAN_IP_ADDR=$( echo "$IP_ADDR" | tr '.' '-' )
+IP_ADDR=$(hostname -I | grep -oP "\b10(\.\d+){3}")
+CLEAN_IP_ADDR=$(echo "$IP_ADDR" | tr '.' '-')
 
 # Echo all the useful information from the `stats` memcache
 # telnet command


### PR DESCRIPTION
We want to take the memcached stats with an IP address in graphite.

We will no longer be running a single global instance of memcached. That
means we need a way to distinguish the running instances. Using the
instance's IP address is a simple distinction.

Not that we "clean" the IP address to use dashes, no dots. Dots are the
separator for graphite stats.

QA
---

Run the script on cominor to see the expected output. As the name
suggests, it will be `piped-to-graphite`.

CC @danielbeardsley

Ref: https://github.com/iFixit/server-templates/issues/1916