### PR TITLE
Add pipe-to-graphite-mcrouter

### DIFF
--- a/scripts/mcrouter-stats.sh
+++ b/scripts/mcrouter-stats.sh
@@ -31,12 +31,10 @@ CLEAN_IP_ADDR=$(echo "$IP_ADDR" | tr '.' '-')
 #
 (
     sleep 1
-    [ "$argument" == "extended" ] && echo "stats slabs" && echo "stats items"
     echo "stats"
     sleep 1
     echo "quit"
-) | telnet localhost 11211 2>/dev/null |
+) | telnet localhost 11222 2>/dev/null |
 grep STAT |
 grep -v version |
-sed -re 's/STAT (items:)?([0-9]+):/memcache.slabs.\2./' \
-     -e "s/STAT /memcache.$CLEAN_IP_ADDR./"
+sed -e "s/STAT /mcrouter.$CLEAN_IP_ADDR./"

--- a/scripts/mcrouter-stats.sh
+++ b/scripts/mcrouter-stats.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+argument="$1"
+
+IP_ADDR=$(hostname -I | grep -oP "\b10(\.\d+){3}")
+CLEAN_IP_ADDR=$(echo "$IP_ADDR" | tr '.' '-')
+
+# Echo all the useful information from the `stats` memcache
+# telnet command
+#
+# Output will resemble this:
+#
+#    memcache.pid 17576
+#    memcache.uptime 1080764
+#    memcache.time 1344234823
+#    memcache.pointer_size 64
+#    memcache.rusage_user 51.160222
+#    memcache.rusage_system 157.221098
+#    memcache.curr_items 181059
+#    memcache.total_items 1948898
+#    memcache.bytes 62620267
+#
+# Output will include this if argument=='extended' (for each slab):
+#
+#    memcache.slabs.5.chunk_size 280
+#    memcache.slabs.5.chunks_per_page 3744
+#    memcache.slabs.5.total_pages 3
+#    memcache.slabs.5.total_chunks 11232
+#    memcache.slabs.5.used_chunks 11226
+#    memcache.slabs.5.free_chunks 6
+#    memcache.slabs.5.free_chunks_end 1849
+#
+(
+    sleep 1
+    [ "$argument" == "extended" ] && echo "stats slabs" && echo "stats items"
+    echo "stats"
+    sleep 1
+    echo "quit"
+) | telnet localhost 11211 2>/dev/null |
+grep STAT |
+grep -v version |
+sed -re 's/STAT (items:)?([0-9]+):/memcache.slabs.\2./' \
+     -e "s/STAT /memcache.$CLEAN_IP_ADDR./"


### PR DESCRIPTION
Add a new script to scrape mcrouter stats and forward them to graphite.

Conveniently, the mcrouter stats mechanism is identical to memcached. We
echo the command `stats`, catch the output, and forward it to graphite.

The major differences are the port we connect on (mcrouter rather than
memcached) and the name of the stat reported.

Additionally, remove the `slabs` extended output support for mcrouter,
as it does not support the slabs command. Mcrouter does not perform any
actual caching, so it does not have any notion of slabs.

CC @danielbeardsley @ davidrans

Ref: https://github.com/iFixit/server-templates/issues/1916